### PR TITLE
[Chapter 3]: Relationships

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,10 +2,23 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Post extends Model
 {
     use HasFactory;
+
+    protected $table = 'posts';
+
+    protected $fillable = [
+        'content',
+        'user_id',
+    ];
+
+    public function user () 
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,11 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Models\Post;
+use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
-use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
@@ -41,4 +42,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class, 'user_id', 'id');
+    }
 }

--- a/database/migrations/2023_08_29_031019_update_posts_table.php
+++ b/database/migrations/2023_08_29_031019_update_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('content');
+            $table->foreignId('user_id');
+            
+            $table->foreign('user_id')->references('id')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};


### PR DESCRIPTION
### 1. Kể tên các quan hệ của Laravel và phương thức tương ứng.

1. One to One:
    - `hasOne()`
    - `belongsTo()`
2. One to Many
    - `hasMany()`
    - `belongsTo()`
3. Many to Many
    - `belongsToMany()`
    - `hasOne()`
4. Has One Of Many
    - `hasOne()`
    - `latestOfMany()`
    - `oldestOfMany()`
    - `ofMany()`
5. Has One Through
    - `hasOneThrough()`
6. Has Many Through
    - `hasManyThrough()`

Đa hình:

1. One to One:
    - `morphTo()`
    - `morphOne()`
2. One to Many:
    - `morphTo()`
    - `morphMany()`
3. Many to Many:
    - `morphToMany()`
    - `morphedByMany()`

### 2. Các hàm attach(), detach(), toggle(), sync() dùng để làm gì?

- attach(): Dùng cho việc thêm thông tin (bản ghi) vào bảng trung gian (pivot table) giữa 2 bảng có quan hệ n-n
- detach(): Dùng cho việc xóa thông tin (bản ghi) khỏi bảng trung gian giữa 2 bảng có quan hệ n-n
- toggle(): Nếu đã có bản ghi ở bảng trung gian thì thực hiện detach(), nếu chưa có thì thực hiện attach()
- sync(): Truyền tham số đầu vào là mảng các id, xóa các bản ghi không có id trong mảng đó.

### 3. Làm thế nào để lấy dữ liệu từ bảng trung gian trong quan hệ n-n?

- Có thể sử dụng thuộc tính `pivot` để truy vập vào bản ghi của bảng trung gian trong quan hệ n-n

```
use App\Models\Order;

$order = Order::find(1);

foreach ($order->items as $item) {
    echo $item->pivot->created_at;
}

```

Model Item được truy xuất sẽ tự động được gán thêm thuộc tính pivot chứa một model thể hiện nội dung bản ghi của bảng trung gian.

Mặc định chỉ các khóa của model trung gian sẽ có trong `pivot`. Nếu bảng trung gian có thuộc tính bổ sung thì cần phải gọi thêm `withPivot()` ở trong hàm định nghĩa relationship.

```
use App\Models\Item;

class Order extends Model {
    public function items() {
        return $this->belongsToMany(Item::class)
            ->withPivot('quantity');
    }
}
```